### PR TITLE
feat: send to multiple channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,34 @@ You can run this script locally by pulling the repo to your local machine.
 
 First, install the dependencies with `npm` or `yarn`.
 
-Then copy the `.env.example` file to `.env` and replace the example values with your own.
+Then copy the `.env.example` file to `.env` and replace the example values with your own. Or set them in your environment manually.
 
+The contract address for the NFT collection:
+```
+CONTRACT_ADDRESS=0x196c4C7291D47BCDBbf37ab7ec9AE7ECB21Aef52
+```
+
+The collection slug as found in the OS URL `https://opensea.io/collection/picassopunks`:
+```
+COLLECTION_SLUG=picassopunks
+```
+
+The Id of the discord channel to post sales to:
+```
+DISCORD_CHANNEL_ID=123456789101112130
+```
+
+You can also send to multiple channels by adding multiple IDs:
+```
+DISCORD_CHANNEL_ID=123456789101112130;123456789101738273;123456783649182736
+```
+
+The token from the discord bot you created above:
+```
+DISCORD_BOT_TOKEN=SBI1MDI0NzUyNDQ3NzgyOTEz.YF36LQ.Sw-rczOfalK0lVzuW8vBjjcnsy0
+```
+
+Then just run the code!
 ```
 $ yarn ts-node ./checkSales.ts
 // or

--- a/checkSales.ts
+++ b/checkSales.ts
@@ -6,15 +6,13 @@ import { ethers } from "ethers";
 const OPENSEA_SHARED_STOREFRONT_ADDRESS = '0x495f947276749Ce646f68AC8c248420045cb7b5e';
 
 const discordBot = new Discord.Client();
-const  discordSetup = async (): Promise<TextChannel> => {
+const  discordSetup = async (channel: string): Promise<TextChannel> => {
+  const channelID = channel
   return new Promise<TextChannel>((resolve, reject) => {
-    ['DISCORD_BOT_TOKEN', 'DISCORD_CHANNEL_ID'].forEach((envVar) => {
-      if (!process.env[envVar]) reject(`${envVar} not set`)
-    })
-  
+    if (!process.env['DISCORD_BOT_TOKEN']) reject('DISCORD_BOT_TOKEN not set')
     discordBot.login(process.env.DISCORD_BOT_TOKEN);
     discordBot.on('ready', async () => {
-      const channel = await discordBot.channels.fetch(process.env.DISCORD_CHANNEL_ID!);
+      const channel = await discordBot.channels.fetch(channelID!);
       resolve(channel as TextChannel);
     });
   })
@@ -39,7 +37,6 @@ const buildMessage = (sale: any) => (
 )
 
 async function main() {
-  const channel = await discordSetup();
   const seconds = process.env.SECONDS ? parseInt(process.env.SECONDS) : 3_600;
   const hoursAgo = (Math.round(new Date().getTime() / 1000) - (seconds)); // in the last hour, run hourly?
   
@@ -60,8 +57,13 @@ async function main() {
     
   return await Promise.all(
     openSeaResponse?.asset_events?.reverse().map(async (sale: any) => {
-      const message = buildMessage(sale);
-      return channel.send(message)
+      if (sale.asset.name == null) sale.asset.name = 'Unnamed NFT';
+      return await Promise.all(
+        process.env.DISCORD_CHANNEL_ID.split(';').map(async (channel: string) => {
+          const message = buildMessage(sale);
+          return await (await discordSetup(channel)).send(message)
+        })
+      )
     })
   );   
 }


### PR DESCRIPTION
_warning: i have never written ts before, and have a beginner level understanding of js in general_

Tried my best at being able to send sales to multiple channels without making multiple API calls for the same collection.

`export DISCORD_CHANNEL_ID='879094113289519174;813159972190945322'`

Also on line 60 I tried to set the name of the NFT if it is `null`, which I have encountered. Can be removed.

If you can guide me on how you'd like this implemented, i can try and tidy it up, otherwise if it is unwanted feel free to close.